### PR TITLE
fix bug when virutalenv_prompt_info and pyenv_prompt_info is both not null

### DIFF
--- a/seeker.zsh-theme
+++ b/seeker.zsh-theme
@@ -1,3 +1,5 @@
+PYENV_PROMPT_DEFAULT_VERSION=${PYENV_PROMPT_DEFAULT_VERSION:="system"}
+
 function _virtualenv_prompt_info {
     if [[ -n "$(whence virtualenv_prompt_info)" ]]; then
         if [ -n "$(whence pyenv_prompt_info)" ]; then
@@ -6,7 +8,7 @@ function _virtualenv_prompt_info {
                 ZSH_THEME_VIRTUAL_ENV_PROMPT_SUFFIX=""
                 virtualenv_prompt_info
             fi
-            [ -z "$(pyenv_prompt_info)" ] && virtualenv_prompt_info
+            [ "$(pyenv_prompt_info)" = "${PYENV_PROMPT_DEFAULT_VERSION}" ] && virtualenv_prompt_info
         else
             virtualenv_prompt_info
         fi
@@ -20,8 +22,6 @@ function _git_prompt_info {
 function _hg_prompt_info {
     [[ -n $(whence hg_prompt_info) ]] && hg_prompt_info
 }
-
-PYENV_PROMPT_DEFAULT_VERSION=${PYENV_PROMPT_DEFAULT_VERSION:="system"}
 
 function _pyenv_prompt_info {
     if [ -n "$(whence pyenv_prompt_info)" ]; then


### PR DESCRIPTION
Hi @tonyseek ,
I have found that if I am using system version in `pyenv`, it can't show me the name of virutalenv in shell.
That is cause `[ -z "$(pyenv_prompt_info)" ]` always return `false`.
And I have fixed this bug, pls review, thanks.
